### PR TITLE
21 fix details page shows incorrect rental status and data

### DIFF
--- a/packages/nextjs/app/manage/[slug]/page.tsx
+++ b/packages/nextjs/app/manage/[slug]/page.tsx
@@ -76,7 +76,7 @@ export default function RentedDomainDetails() {
     );
   }
 
-  const endTime = rental.rentals?.[0]?.endTime;
+  const endTime = rental.rentals?.[0].endTime;
 
   return (
     <div className="min-h-screen bg-gray-100 p-4">
@@ -233,16 +233,18 @@ export default function RentedDomainDetails() {
               <ExternalLink className="w-4 h-4" />
               View on Etherscan
             </Button>
-            <Button asChild>
-              <Link
-                className="flex items-center gap-2"
-                target="_blank"
-                href={`https://app.ens.domains/${domain}`}
-              >
-                <ExternalLink className="w-4 h-4" />
-                Manage your rented domain
-              </Link>
-            </Button>
+            {rental.status === RentalStatus.rentedIn && (
+              <Button asChild>
+                <Link
+                  className="flex items-center gap-2"
+                  target="_blank"
+                  href={`https://app.ens.domains/${domain}`}
+                >
+                  <ExternalLink className="w-4 h-4" />
+                  Manage your rented domain
+                </Link>
+              </Button>
+            )}
           </CardFooter>
         </Card>
       </div>

--- a/packages/nextjs/app/manage/[slug]/page.tsx
+++ b/packages/nextjs/app/manage/[slug]/page.tsx
@@ -76,6 +76,8 @@ export default function RentedDomainDetails() {
     );
   }
 
+  const endTime = rental.rentals?.[0]?.endTime;
+
   return (
     <div className="min-h-screen bg-gray-100 p-4">
       <div className="container mx-auto py-8 max-w-4xl space-y-6">
@@ -134,9 +136,7 @@ export default function RentedDomainDetails() {
                     <span>Time Remaining</span>
                   </div>
                   <div className="text-2xl font-bold">
-                    {rental.maxRentalTime
-                      ? getRemainingTime(rental.maxRentalTime)
-                      : '-'}
+                    {endTime ? getRemainingTime(endTime.toString()) : '-'}
                   </div>
                 </div>
               </div>
@@ -259,7 +259,7 @@ const formatDate = (date: number): string => {
 
 const getRemainingTime = (endDate: string) => {
   const now = new Date();
-  const end = new Date(parseInt(endDate) * 1000);
+  const end = new Date(parseInt(endDate));
   const diff = end.getTime() - now.getTime();
 
   // Return early if already expired

--- a/packages/nextjs/hooks/graphql/useDomainData/utils.ts
+++ b/packages/nextjs/hooks/graphql/useDomainData/utils.ts
@@ -23,6 +23,7 @@ export function determineRentalStatus(
   address?: string
 ): RentalStatus {
   const now = Math.floor(Date.now() / 1000);
+
   const rentalExpiry = mostRecentRental?.endTime
     ? parseInt(mostRecentRental.endTime)
     : 0;
@@ -31,6 +32,8 @@ export function determineRentalStatus(
     return RentalStatus.rentedOut;
   } else if (mostRecentRental?.borrower === address && rentalExpiry > now) {
     return RentalStatus.rentedIn;
+  } else if (rentalExpiry < now) {
+    return RentalStatus.expired;
   } else {
     return RentalStatus.listed;
   }


### PR DESCRIPTION
# Details Page Shows Incorrect Rental Status and Data

## Description
The details page for a rented domain (e.g., `robertin.eth`) is showing incorrect information. Specifically, it displays the domain as “listed” when it is actually rented, and the rental data (dates, status) appear to be wrong. This raises the question of whether the details page is pulling in mocked data instead of the actual domain status.

## Steps to Reproduce
1. Go to the manage page for a domain that is already rented (e.g., `robertin.eth`).
2. Observe the “Details” section.
3. Note that the page claims the domain is listed, even though it is rented, and shows unexpected rental dates.

## Expected Behavior
- The details page should accurately reflect the domain’s current rental status (rented vs. listed).
- The rental period and expiration date displayed should match the actual data.

## Actual Behavior
- The page shows the domain as listed despite being rented.
- The displayed dates for the rental period appear to be incorrect or mocked.

## Possible Causes
- The details page may be using outdated or mocked data instead of the real rental status.
- There could be an API call or data fetching issue leading to incorrect status/dates.

<img width="868" alt="Image" src="https://github.com/user-attachments/assets/11688d4b-3d65-407e-b7cd-2f3097b19cd6" />

<img width="1106" alt="Image" src="https://github.com/user-attachments/assets/7c7d4e50-6908-47fc-bbb5-23748a95b17e" />